### PR TITLE
UN-8536: updates for M1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM unionpos/aws-vault:5.2.0 AS aws-vault
 FROM unionpos/chamber:2.7.5 AS chamber
 
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 ENV DEBIAN_FRONTEND="noninteractive"
 

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,10 @@ push:
 .PHONY: push
 
 run:
-	$(DOCKER) container run --rm --platform linux/amd64 \
+	$(DOCKER) container run --rm ${DOCKER_BUILD_FLAGS} \
 		--attach STDOUT ${DOCKER_IMAGE_NAME}
 .PHONY: run
 
 it:
-	$(DOCKER) run -it --platform linux/amd64 ${DOCKER_IMAGE_NAME} /bin/bash
+	$(DOCKER) run -it ${DOCKER_BUILD_FLAGS} ${DOCKER_IMAGE_NAME} /bin/bash
 .PHONY: it

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 export DOCKER_ORG ?= unionpos
 export DOCKER_IMAGE ?= $(DOCKER_ORG)/ubuntu
-export DOCKER_TAG ?= 16.04
+export DOCKER_TAG ?= 18.04
 export DOCKER_IMAGE_NAME ?= $(DOCKER_IMAGE):$(DOCKER_TAG)
-export DOCKER_BUILD_FLAGS =
+export DOCKER_BUILD_FLAGS = --platform linux/amd64
 
 -include $(shell curl -sSL -o .build-harness "https://raw.githubusercontent.com/unionpos/build-harness/master/templates/Makefile.build-harness"; echo .build-harness)
 

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,10 @@ push:
 .PHONY: push
 
 run:
-	$(DOCKER) container run --rm \
+	$(DOCKER) container run --rm --platform linux/amd64 \
 		--attach STDOUT ${DOCKER_IMAGE_NAME}
 .PHONY: run
 
 it:
-	$(DOCKER) run -it ${DOCKER_IMAGE_NAME} /bin/bash
+	$(DOCKER) run -it --platform linux/amd64 ${DOCKER_IMAGE_NAME} /bin/bash
 .PHONY: it


### PR DESCRIPTION
## What and Why
Update base Ubuntu image from 16.04 to 18.04.  

It will be saved in docker hub as `unionpos/ubuntu:18.04`

## Related Tickets and PRs

Fixes [UN-8536](https://tabbedout.atlassian.net/browse/UN-8536)

## Steps to Test


## Humor for Reviewer

[UN-8536]: https://tabbedout.atlassian.net/browse/UN-8536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ